### PR TITLE
Fix high idle CPU usage on Windows

### DIFF
--- a/tick.lua
+++ b/tick.lua
@@ -49,9 +49,12 @@ love.run = function()
       tick.tick = tick.tick + 1
       if love.update then love.update(tick.rate) end
     end
-
-    while tick.framerate and timer.getTime() - lastframe < 1 / tick.framerate do
-      timer.sleep(.0005)
+    
+    if tick.framerate then 
+      local affinity = math.min(0.85, 0.96655 - 0.0019425 * tick.framerate)
+      while timer.getTime() - lastframe < 1 / tick.framerate do
+        if timer.getTime() - lastframe <  1 / tick.framerate * affinity then timer.sleep(0.001) end
+      end
     end
 
     lastframe = timer.getTime()


### PR DESCRIPTION
Running a project rendering a rectangle and a simple gradient shader at 60fps, it was taking up 14-17% of my CPU.
Added a small check so it sleeps only when necessary, at a reasonable stability.
CPU usage is now 2-4%. 
Compared to an empty project at the same fps and no libraries, the difference is just 1%.
I did run it on Linux, 1-3% usage vs 5% originally.

An adaptive affinity was added to compensate for high fps. Lower values produce more consistent frametimes at the cost of higher CPU usage.
The affinity formula is simplified from this equation: `( 1 - (tick.framerate - 60) / (240-60) ) * 0.35 + 0.5`

Tested in LÖVE 11.5